### PR TITLE
Use safeAreaLayoutGuide directly when creating constraints

### DIFF
--- a/MapwizeUI/BottomInfoView/MWZComponentBottomInfoView.m
+++ b/MapwizeUI/BottomInfoView/MWZComponentBottomInfoView.m
@@ -176,6 +176,22 @@
                                                                                       constant:16.0f];
     directionConstraintToTitle.priority = 1000;
     [directionConstraintToTitle setActive:YES];
+    id directionConstraintToBottomItem;
+    if (@available(iOS 11.0, *)) {
+        directionConstraintToBottomItem = self.safeAreaLayoutGuide;
+    } else {
+        directionConstraintToBottomItem = self;
+    }
+    
+    NSLayoutConstraint* directionConstraintToBottom = [NSLayoutConstraint constraintWithItem:directionButton
+                                                                                   attribute:NSLayoutAttributeBottom
+                                                                                   relatedBy:NSLayoutRelationEqual
+                                                                                      toItem:directionConstraintToBottomItem
+                                                                                   attribute:NSLayoutAttributeBottom
+                                                                                  multiplier:1.0f
+                                                                                    constant:-16.0f];
+    directionConstraintToBottom.priority = 750;
+    [directionConstraintToBottom setActive:YES];
     
     UIImage* infoImage = [UIImage imageNamed:@"info" inBundle:bundle compatibleWithTraitCollection:nil];
     infoImage = [infoImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
@@ -212,6 +228,16 @@
     [informationsConstraintToTitle setActive:YES];
     
     
+    NSLayoutConstraint* informationsConstraintToBottom = [NSLayoutConstraint constraintWithItem:informationsButton
+                                                                                      attribute:NSLayoutAttributeBottom
+                                                                                      relatedBy:NSLayoutRelationEqual
+                                                                                         toItem:directionButton
+                                                                                      attribute:NSLayoutAttributeBottom
+                                                                                     multiplier:1.0f
+                                                                                       constant:0];
+    
+    informationsConstraintToBottom.priority = 750;
+    [informationsConstraintToBottom setActive:YES];
     
     
 }
@@ -326,28 +352,6 @@
         }
     }
     
-}
-
-- (void) safeAreaInsetsDidChange {
-    NSLayoutConstraint* directionConstraintToBottom = [NSLayoutConstraint constraintWithItem:directionButton
-                                                                                   attribute:NSLayoutAttributeBottom
-                                                                                   relatedBy:NSLayoutRelationEqual
-                                                                                      toItem:self
-                                                                                   attribute:NSLayoutAttributeBottom
-                                                                                  multiplier:1.0f
-                                                                                    constant:-16.0f - self.safeAreaInsets.bottom];
-    directionConstraintToBottom.priority = 750;
-    [directionConstraintToBottom setActive:YES];
-    
-    NSLayoutConstraint* informationsConstraintToBottom = [NSLayoutConstraint constraintWithItem:informationsButton
-                                                                                   attribute:NSLayoutAttributeBottom
-                                                                                   relatedBy:NSLayoutRelationEqual
-                                                                                      toItem:self
-                                                                                   attribute:NSLayoutAttributeBottom
-                                                                                  multiplier:1.0f
-                                                                                    constant:-16.0f - self.safeAreaInsets.bottom];
-    informationsConstraintToBottom.priority = 750;
-    [informationsConstraintToBottom setActive:YES];
 }
 
 @end

--- a/MapwizeUI/MapwizeView/MWZMapwizeView.m
+++ b/MapwizeUI/MapwizeView/MWZMapwizeView.m
@@ -437,6 +437,13 @@ const CGFloat marginRight = 16;
                                       attribute:NSLayoutAttributeLeft
                                      multiplier:1.0f
                                        constant: self.safeAreaInsets.left + 8.0f] setActive:YES];
+        [[NSLayoutConstraint constraintWithItem:searchBar
+                                      attribute:NSLayoutAttributeTop
+                                      relatedBy:NSLayoutRelationEqual
+                                         toItem:self.safeAreaLayoutGuide
+                                      attribute:NSLayoutAttributeTop
+                                     multiplier:1.0f
+                                       constant:8.0f] setActive:YES];
     } else {
         [[NSLayoutConstraint constraintWithItem:searchBar
                                       attribute:NSLayoutAttributeRight
@@ -450,6 +457,13 @@ const CGFloat marginRight = 16;
                                       relatedBy:NSLayoutRelationEqual
                                          toItem:self
                                       attribute:NSLayoutAttributeLeft
+                                     multiplier:1.0f
+                                       constant:8.0f] setActive:YES];
+        [[NSLayoutConstraint constraintWithItem:searchBar
+                                      attribute:NSLayoutAttributeTop
+                                      relatedBy:NSLayoutRelationEqual
+                                         toItem:self
+                                      attribute:NSLayoutAttributeTop
                                      multiplier:1.0f
                                        constant:8.0f] setActive:YES];
     }
@@ -855,27 +869,6 @@ const CGFloat marginRight = 16;
         [_mapwizePlugin setIndoorLocationProvider:indoorLocationProvider];
     }
 }
-    
-#pragma mark SafeAreaInsets
-
-- (void) safeAreaInsetsDidChange {
-    if (searchBarTopConstraint == nil) {
-        searchBarTopConstraint = [NSLayoutConstraint constraintWithItem:searchBar
-                                                              attribute:NSLayoutAttributeTop
-                                                              relatedBy:NSLayoutRelationEqual
-                                                                 toItem:self
-                                                              attribute:NSLayoutAttributeTop
-                                                             multiplier:1.0f
-                                                               constant: self.safeAreaInsets.top + 8.0f];
-        [searchBarTopConstraint setActive:YES];
-    }
-    else {
-        searchBarTopConstraint.constant = self.safeAreaInsets.top + 8.0f;
-    }
-}
-
-
-
 
 #pragma mark MWZMapwizePluginDelegate
 


### PR DESCRIPTION
# Problem
In some cases when layout is more complex `safeAreaInsetsDidChange` is not called on iPhone 8 and older. 
# Solution
In this PR I moved some constraints creation from `safeAreaInsetsDidChange` to initialization method. Also added relation to `safeAreaLayoutGuide` if possible, rather than modifying constraint constant.