### PR TITLE
Close floor component if number of floors is less or equal than 1

### DIFF
--- a/MapwizeUI/FloorController/MWZComponentFloorController.m
+++ b/MapwizeUI/FloorController/MWZComponentFloorController.m
@@ -35,7 +35,7 @@ const int MWZComponentFloorViewMarginSize = 5;
 }
 
 - (void) mapwizeFloorsDidChange:(NSArray<NSNumber*>*) floors {
-    if (!floors || floors.count == 0) {
+    if (!floors || floors.count <= 1) {
         [self close];
         return;
     }


### PR DESCRIPTION
**Problem**
Floor component is visible even if venue only has one floor 

**Solution**
In this PR I close MWZComponentFloorController is number of floors 0 or 1